### PR TITLE
build: better cache invalidation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ gpgcheck=0\n\
 enabled=1\n\
 metadata_expire=0\n" >/etc/yum.repos.d/metwork.repo
 ARG CACHEBUST=0
-RUN yum --disablerepo=* --enablerepo=metwork_${BRANCH} -q list metwork-* 2>/dev/null |sort |md5sum |awk '{print $1;}' > /tmp/yum_cache
+RUN yum --disablerepo=* --enablerepo=metwork_${BRANCH} -q list metwork-mfcom* 2>/dev/null |sort |md5sum |awk '{print $1;}' > /tmp/yum_cache
 
 FROM metwork/mfcom-centos7-buildimage:${BRANCH}
 COPY --from=yum_cache /etc/yum.repos.d/metwork.repo /etc/yum.repos.d/


### PR DESCRIPTION
If a new mfadmin package was build (for example), the cache was invalidated here.